### PR TITLE
Added ugly af stats display

### DIFF
--- a/src/app/applications/applications.component.html
+++ b/src/app/applications/applications.component.html
@@ -3,6 +3,15 @@
     <md-card-title><h1>Applications</h1></md-card-title>
   </md-card-header>
   <md-card-content>
+    Apps left to review: {{stats.pending_internal}}<br>
+    Currently Accepted: {{stats.accepted_public}}<br>
+    Currently Waitlisted: {{stats.waitlisted_public}}<br>
+    Currently Rejected: {{stats.rejected_public}}<br>
+    Internally Accepted: {{stats.accepted_internal}} ({{stats.accepted_internal - stats.accepted_public}})<br>
+    Internally Waitlisted: {{stats.waitlisted_internal}} ({{stats.waitlisted_internal - stats.waitlisted_public}})<br>
+    Internally Rejected: {{stats.rejected_internal}} ({{stats.rejected_internal - stats.rejected_public}})<br>
+  </md-card-content>
+  <md-card-content>
     <a [routerLink]="['/application', app.id]"  *ngFor="let app of applications">
       <md-card>
         <h3 md-line> {{app.user.firstname}} {{app.user.lastname}} </h3>

--- a/src/app/applications/applications.component.ts
+++ b/src/app/applications/applications.component.ts
@@ -5,6 +5,7 @@ import { User } from "../user";
 import { Application } from '../application';
 import { UserService } from "../services/index";
 import { ApplicationService } from "../services/index";
+import { ExecService } from "../services/index";
 
 @Component({
   selector: 'app-applications',
@@ -14,10 +15,11 @@ import { ApplicationService } from "../services/index";
 export class ApplicationsComponent implements OnInit {
   currentUser: User;
   applications: Application[] = [];
-
+  stats: {} = {};
   constructor(
     private userService: UserService,
     private appService: ApplicationService,
+    private execService: ExecService,
     private route: ActivatedRoute,
     private router: Router) {
       this.currentUser = userService.loadFromLocalStorage();
@@ -33,6 +35,15 @@ export class ApplicationsComponent implements OnInit {
           console.log(error);
         }
     );
+
+    this.execService.getStats()
+      .subscribe(
+        result => {
+          this.stats = result;
+        }, error => {
+          console.log(error);
+        }
+      )
   }
 
   onSelect(app: Application) {


### PR DESCRIPTION
Added an incredibly ugly (but working) stats display on the admin page. It shows the counts for currently accepted/waitlisted/rejected applications as well as the intern counts and the difference. We'll need design to format this so it's understandable. 